### PR TITLE
flask dependency version fix

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.2.2
 requests==2.28.1
 python-dotenv==0.21.0
+Werkzeug==2.2.2


### PR DESCRIPTION
Werkzeug 3.0.0 was released and Flask doesn't specify the dependency correctly (requirements says Werkzeug>=2.2.0). This is why, Werkzeug 3.0.0 is still installed and Flask 2.2.2 isn't made for Werkzeug 3.0.0.
So fixing the dependency by installing `Werkzeug==2.2.2`