### PR TITLE
added  a file to fetch refresh token wihout using curl command 

### DIFF
--- a/api/getrefresh.py
+++ b/api/getrefresh.py
@@ -1,0 +1,47 @@
+import base64
+import requests
+from urllib.parse import urlencode
+
+# Your Spotify app's client ID and client secret
+client_id = '86fe8b2768664f2ba22fba6ba9a3e2d1'
+client_secret = '579ce9f6c48f4af2b06b0e06a4352af9'
+
+# The redirect URI you set in your Spotify app settings
+redirect_uri = 'http://localhost/callback/'
+
+# The base64 encoded string of your client ID and client secret
+client_creds = f"{client_id}:{client_secret}"
+client_creds_b64 = base64.b64encode(client_creds.encode())
+
+# The URL the user will be redirected to for login
+auth_url = 'https://accounts.spotify.com/authorize'
+auth_data = {
+    'client_id': client_id,
+    'response_type': 'code',
+    'redirect_uri': redirect_uri,
+    'scope': 'user-read-private'  # Change this to the scopes you need
+}
+auth_params = urlencode(auth_data)
+
+print(f"Please go to the following URL to authorize the app: {auth_url}?{auth_params}")
+
+# After the user logs in, they will be redirected to the redirect URI with a code in the query string
+auth_code = input("Enter the code from the query string: ")
+
+# Use the code to get an access token and refresh token
+token_url = 'https://accounts.spotify.com/api/token'
+token_data = {
+    'grant_type': 'authorization_code',
+    'code': auth_code,
+    'redirect_uri': redirect_uri
+}
+token_headers = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Authorization': f"Basic {client_creds_b64.decode()}"
+}
+
+response = requests.post(token_url, data=token_data, headers=token_headers)
+response_data = response.json()
+
+print(f"Access token: {response_data['access_token']}")
+print(f"Refresh token: {response_data['refresh_token']}")

--- a/api/getrefresh.py
+++ b/api/getrefresh.py
@@ -3,8 +3,8 @@ import requests
 from urllib.parse import urlencode
 
 # Your Spotify app's client ID and client secret
-client_id = '86fe8b2768664f2ba22fba6ba9a3e2d1'
-client_secret = '579ce9f6c48f4af2b06b0e06a4352af9'
+client_id = '**'
+client_secret = '**'
 
 # The redirect URI you set in your Spotify app settings
 redirect_uri = 'http://localhost/callback/'

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.2.2
+Flask==3.0.2
 requests==2.28.1
 python-dotenv==0.21.0


### PR DESCRIPTION
i  have added an additional getrefresh.py file to automate the process of fetching the refresh token thus eliminating some installation steps 

on running the code you will get a link and you click on it and log in to spotify and get auth code .
this is an alternate to using the curl command which is not "FOOL proof"
heres how it works 

1.run the code 
2. it will give you a spotify login auth link
3. copy code and enter it in the prompt
4. you will get refresh token and access token(optional can be removed . added cus i needed it)
5. done


iv attached a screenshot for proof 
![Uploading Screenshot 2024-02-19 at 7.36.10 PM.png…]()
