### PR TITLE
fix: #25 dependencies and feat: #10 redirect to current song

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,11 @@ https://accounts.spotify.com/authorize?client_id={CLIENT_ID}&response_type=code&
 * In any markdown file, add the following (replace `{PROJECT_NAME}` with the name you gave your Vercel project):
 
   ```html
-  <a href="https://github.com/tthn0/Spotify-Readme">
+  <a href="https://{PROJECT_NAME}.vercel.app/api/play">
     <img src="https://{PROJECT_NAME}.vercel.app/api" alt="Current Spotify Song">
   </a>
+  
+  <a href="https://github.com/tthn0/Spotify-Readme">Source Repo</a>
   ```
 
 * Please leave the anchor tag hyperlink reference to this GitHub repo to retain creator credit and for other users to find! 

--- a/api/index.py
+++ b/api/index.py
@@ -136,15 +136,6 @@ app = Flask(__name__)
 
 
 @app.route("/", defaults={"path": ""})
-@app.route("/play")
-def play():
-    data = spotify_request("me/player/currently-playing")
-    if data:
-        id = data["item"]["id"]
-    else:
-        id = spotify_request(
-            "me/player/recently-played?limit=1")["items"][0]["track"]["id"]
-    return redirect(f"https://open.spotify.com/track/{id}")
 @app.route("/<path:path>")
 def catch_all(path):
     resp = Response(
@@ -159,6 +150,15 @@ def catch_all(path):
     resp.headers["Cache-Control"] = "s-maxage=1"
     return resp
 
+@app.route("/api/play")
+def play():
+    data = spotify_request("me/player/currently-playing")
+    if data:
+        id = data["item"]["id"]
+    else:
+        id = spotify_request(
+            "me/player/recently-played?limit=1")["items"][0]["track"]["id"]
+    return redirect(f"https://open.spotify.com/track/{id}")
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.2.2
-requests==2.28.1
-python-dotenv==0.21.0
+Flask
+requests
+python-dotenv

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -147,7 +147,7 @@
                     }
                 }
             </style>
-            <a href="{{ request.url_root }}play" target="_blank">
+            <a href="{{ request.url_root }}api/play" target="_blank">
                 <main>
                     {% if scan_code %}
                         <img class="scan-code" src="data:image/png;base64, {{scan_code}}" alt="Scan Code" />

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+    "routes": [{
+        "src": "/api/(.*)",
+        "dest": "api/index.py"
+    }]
+}


### PR DESCRIPTION
PR #16 works fine locally but doesn't work on Vercel. 

Adding this:
`vercel.json`
```json
{
    "routes": [{
        "src": "/api/(.*)",
        "dest": "api/index.py"
    }]
}
```
fixed the issue

Working deployment: https://spotify-readme-8i1rak5nw-42willows.vercel.app/api



---

I'm not sure if I should lock the dependencies, it's probably good practice to